### PR TITLE
add setup-sh script for installing dependencies and setting python3

### DIFF
--- a/git-split-commit
+++ b/git-split-commit
@@ -3,6 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 set -e
+[ -d $SCRIPT_DIR/pyenv ] && . $SCRIPT_DIR/pyenv/bin/activate
 
 RESET=0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pygments==2.12.0
+termcolor==1.1.0
+unidiff==0.7.3

--- a/setup-sh
+++ b/setup-sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd $SCRIPT_DIR
+virtualenv pyenv
+echo '*' > pyenv/.gitignore
+. pyenv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
Add a quick simple bash script for installing the python3 dependencies that are needed to run the main script, assuming already that virtualenv is installed with python3.